### PR TITLE
[ci] Filter GitHub pull request events

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -92,7 +92,7 @@ tasks:
       then:
         # Taskcluster responds to a number of events issued by the GitHub API
         # which should not trigger re-validation.
-        $if: event.action in ['opened', 'reopened', 'synchronized']
+        $if: event.action in ['opened', 'reopened', 'synchronize']
         then:
           $map: [{name: firefox, channel: nightly}, {name: chrome, channel: dev}]
           each(browser):

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -90,67 +90,71 @@ tasks:
                     --total-chunks=${chunk[2]};
     - $if: tasks_for == "github-pull-request"
       then:
-        $map: [{name: firefox, channel: nightly}, {name: chrome, channel: dev}]
-        each(browser):
-          $map:
-            - name: wpt-${browser.name}-${browser.channel}-stability
-              description: >-
-                Verify that all tests affected by a pull request are stable
-                when executed in ${browser.name}.
-              extra_args: '--verify'
-            - name: wpt-${browser.name}-${browser.channel}-results
-              description: >-
-                Collect results for all tests affected by a pull request in
-                ${browser.name}.
-              extra_args: '--no-fail-on-unexpected --log-wptreport=../artifacts/wpt_report.json'
-          each(operation):
-            taskId: {$eval: 'as_slugid(operation.name)'}
-            taskGroupId: {$eval: 'as_slugid("task group")'}
-            created: {$fromNow: ''}
-            deadline: {$fromNow: '24 hours'}
-            provisionerId: aws-provisioner-v1
-            workerType:
-              $if: event.repository.full_name == 'web-platform-tests/wpt'
-              then:
-                wpt-docker-worker
-              else:
-                github-worker
-            metadata:
-              name: ${operation.name}
-              description: ${operation.description}
-              owner: ${event.pull_request.user.login}@users.noreply.github.com
-              source: ${event.repository.url}
-            payload:
-              image: jugglinmike/web-platform-tests:0.21
-              maxRunTime: 7200
-              artifacts:
-                public/results:
-                  path: /home/test/artifacts
-                  type: directory
-              # Fetch the GitHub-provided merge commit (rather than the pull
-              # request branch) so that the tasks simulate the behavior of the
-              # submitted patch after it is merged. Using the merge commit also
-              # simplifies detection of modified files because the first parent
-              # of the merge commit can consistently be used to summarize the
-              # changes.
-              command:
-                - /bin/bash
-                - --login
-                - -c
-                - set -ex;
-                  ~/start.sh
-                    ${event.repository.clone_url}
-                    refs/pull/${event.number}/merge
-                    FETCH_HEAD
-                    ${browser.name}
-                    ${browser.channel};
-                  cd ~/web-platform-tests;
-                  result=0;
-                  ./tools/ci/taskcluster-run.py
-                    --commit-range HEAD^
-                    ${browser.name}
-                    --
-                    --channel=${browser.channel}
-                    ${operation.extra_args} || result=$?;
-                  echo $result > ../artifacts/run-return-code.txt;
-                  echo "Command exited with code $result (failures are allowed while this task is being vetted)."
+        # Taskcluster responds to a number of events issued by the GitHub API
+        # which should not trigger re-validation.
+        $if: event.action in ['opened', 'reopened', 'synchronized']
+        then:
+          $map: [{name: firefox, channel: nightly}, {name: chrome, channel: dev}]
+          each(browser):
+            $map:
+              - name: wpt-${browser.name}-${browser.channel}-stability
+                description: >-
+                  Verify that all tests affected by a pull request are stable
+                  when executed in ${browser.name}.
+                extra_args: '--verify'
+              - name: wpt-${browser.name}-${browser.channel}-results
+                description: >-
+                  Collect results for all tests affected by a pull request in
+                  ${browser.name}.
+                extra_args: '--no-fail-on-unexpected --log-wptreport=../artifacts/wpt_report.json'
+            each(operation):
+              taskId: {$eval: 'as_slugid(operation.name)'}
+              taskGroupId: {$eval: 'as_slugid("task group")'}
+              created: {$fromNow: ''}
+              deadline: {$fromNow: '24 hours'}
+              provisionerId: aws-provisioner-v1
+              workerType:
+                $if: event.repository.full_name == 'web-platform-tests/wpt'
+                then:
+                  wpt-docker-worker
+                else:
+                  github-worker
+              metadata:
+                name: ${operation.name}
+                description: ${operation.description}
+                owner: ${event.pull_request.user.login}@users.noreply.github.com
+                source: ${event.repository.url}
+              payload:
+                image: jugglinmike/web-platform-tests:0.21
+                maxRunTime: 7200
+                artifacts:
+                  public/results:
+                    path: /home/test/artifacts
+                    type: directory
+                # Fetch the GitHub-provided merge commit (rather than the pull
+                # request branch) so that the tasks simulate the behavior of the
+                # submitted patch after it is merged. Using the merge commit also
+                # simplifies detection of modified files because the first parent
+                # of the merge commit can consistently be used to summarize the
+                # changes.
+                command:
+                  - /bin/bash
+                  - --login
+                  - -c
+                  - set -ex;
+                    ~/start.sh
+                      ${event.repository.clone_url}
+                      refs/pull/${event.number}/merge
+                      FETCH_HEAD
+                      ${browser.name}
+                      ${browser.channel};
+                    cd ~/web-platform-tests;
+                    result=0;
+                    ./tools/ci/taskcluster-run.py
+                      --commit-range HEAD^
+                      ${browser.name}
+                      --
+                      --channel=${browser.channel}
+                      ${operation.extra_args} || result=$?;
+                    echo $result > ../artifacts/run-return-code.txt;
+                    echo "Command exited with code $result (failures are allowed while this task is being vetted)."


### PR DESCRIPTION
The complete list of event "actions" emitted by GitHub (and recognized
by Taskcluster) is [1]:

> - assigned
> - unassigned
> - labeled
> - unlabeled
> - opened
> - edited
> - closed
> - reopened
> - synchronize
> - review_requested
> - review_request_removed

Most of these have no bearing on the code under review, so they should
not trigger validation.

Do not validate commits in response to irrelevant events.

[1] https://docs.taskcluster.net/docs/reference/integrations/taskcluster-github/references/events